### PR TITLE
Fixes to use an embeded version of Chef client

### DIFF
--- a/gecosws_config_assistant/controller/ConnectWithGecosCCController.py
+++ b/gecosws_config_assistant/controller/ConnectWithGecosCCController.py
@@ -72,7 +72,7 @@ class ConnectWithGecosCCController(object):
         self.logger = logging.getLogger('ConnectWithGecosCCController')
 
         # List of GEMS required to run GECOS 
-        self.necessary_gems = ['json', 'rest-client', 'activesupport', 'sqlite3', 'netaddr']
+        self.necessary_gems = ['json', 'rest-client', 'activesupport', 'netaddr']
 
     def show(self, mainWindow):
         self.logger.debug('show - BEGIN')

--- a/gecosws_config_assistant/util/GemUtil.py
+++ b/gecosws_config_assistant/util/GemUtil.py
@@ -98,7 +98,7 @@ class GemUtil(object):
                 # We will need 'build-essential' package to build GEMs
                 self.pm.install_package('build-essential')
             
-        return self.commandUtil.execute_command('%s install "%s"'%(self.command, gem_name))
+        return self.commandUtil.execute_command('%s install "%s"'%(self.command, gem_name), os.environ)
 
     def uninstall_gem(self, gem_name):
         if not self.rubyEmbeddedInChef:


### PR DESCRIPTION
In embedded versions of Chef client the GEMs must be built by compiling them. If any dependency is missing or the environment is not properly set the building process may fail.