### PR TITLE
Ruby gems repository from ini file

### DIFF
--- a/data/report-handlers/gecoshandlers.rb
+++ b/data/report-handlers/gecoshandlers.rb
@@ -23,7 +23,7 @@ module GECOSReports
         begin
           has_conection = false
           tries = 0
-          dns_resolver = Resolv::DNS.new()
+          dns_resolver = Resolv.new()
           while (not has_conection and tries < 10 and not gcc_control.nil? and 
                 gcc_control.key?("uri_gcc") and not gcc_control['uri_gcc'].nil? and 
                 not gcc_control['uri_gcc'].empty?)

--- a/gecosws_config_assistant/util/GemUtil.py
+++ b/gecosws_config_assistant/util/GemUtil.py
@@ -75,15 +75,19 @@ class GemUtil(object):
     # Adding only gecoscc.ini source ("gem_repo")
     # The gem add command adds https://rubygems.org source by default. We must manually delete it.
     def add_gem_only_one_source(self, url):
+        sources = self.get_gem_sources_list()
 
+        self.logger.debug("adding gem source from gecoscc.ini: %s" % (url))
         res = self.add_gem_source(url)
-        # Remove default source
-        res &= self.commandUtil.execute_command('%s source -r "%s" --config-file "%s"'%(self.command,'https://rubygems.org/', self.sys_gemrc))
 
-        if res and url == 'https://rubygems.org/':
-            res = self.add_gem_source(url)
+        self.logger.debug("deleting all the other sources")
+        for source in sources:
+            if source != url:
+                self.logger.debug("removing %s from gem sources" % (source))
+                res &= self.commandUtil.execute_command('%s source -r "%s" --config-file "%s"'%(self.command, source, self.sys_gemrc))
 
         return res
+
     def add_gem_source(self, url):
         return self.commandUtil.execute_command('%s source -a "%s" --config-file "%s"'%(self.command, url, self.sys_gemrc))
 


### PR DESCRIPTION
It has been changed the way GCA was managing Ruby gems repostories. From now on, there will be only one repo available to download gems, that from `gecoscc.ini` file.

And also, `report-handler` used to ignore `/etc/hosts` file and used only DNS resolver from `/etc/resolver.conf`. Now it uses both.

