### PR TITLE
Chef SSL certificate error and show info message for authentication method type

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gecosws-config-assistant (2.1.4-1gecos1) trusty; urgency=medium
+
+  * Fix Chef SSL certificate error
+
+ -- Gecos Team <gecos@guadalinex.org>  Wed, 02 Jul 2018 12:00:00 +0100
+
 gecosws-config-assistant (2.1.3-1gecos1) trusty; urgency=medium
 
   * Installs local certificates for https connections

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Gecos Team <gecos@guadalinex.org>
 Build-Depends: debhelper (>= 8), cdbs (>=0.4.43), python-all-dev (>=2.3.5-11), python-support, git
 Build-Depends-Indep: gettext, python-distutils-extra
-Standards-Version: 3.8.3
+Standards-Version: 2.1.4-1gecos1
 Homepage: https://github.com/gecos-team/gecosws-config-assistant
 Vcs-Browser: https://github.com/gecos-team/gecosws-config-assistant
 Vcs-Bzr: https://github.com/gecos-team/gecosws-config-assistant

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Gecos Team <gecos@guadalinex.org>
 Build-Depends: debhelper (>= 8), cdbs (>=0.4.43), python-all-dev (>=2.3.5-11), python-support, git
 Build-Depends-Indep: gettext, python-distutils-extra
-Standards-Version: 2.1.4-1gecos1
+Standards-Version: 3.8.3
 Homepage: https://github.com/gecos-team/gecosws-config-assistant
 Vcs-Browser: https://github.com/gecos-team/gecosws-config-assistant
 Vcs-Bzr: https://github.com/gecos-team/gecosws-config-assistant

--- a/gecosws_config_assistant/controller/UserAuthenticationMethodController.py
+++ b/gecosws_config_assistant/controller/UserAuthenticationMethodController.py
@@ -339,7 +339,7 @@ class UserAuthenticationMethodController(object):
             
             if self.dao.delete(oldData):
                 # Set new authentication method
-                if self.dao.save(newData)
+                if self.dao.save(newData):
                     self.logger.debug("Authentication method saved!")
                     showinfo_gtk(_("Authentication method saved!"),self.view)
                     return True

--- a/gecosws_config_assistant/controller/UserAuthenticationMethodController.py
+++ b/gecosws_config_assistant/controller/UserAuthenticationMethodController.py
@@ -22,7 +22,7 @@ __license__ = "GPL-2"
 
 import sys
 
-from gecosws_config_assistant.view.CommonDialog import askyesno_gtk, showerror_gtk
+from gecosws_config_assistant.view.CommonDialog import askyesno_gtk, showerror_gtk, showinfo_gtk
 from gecosws_config_assistant.view.ADSetupDataElemView import ADSetupDataElemView
 from gecosws_config_assistant.view.UserAuthDialog import UserAuthDialog, LOCAL_USERS, LDAP_USERS, AD_USERS
 
@@ -339,7 +339,13 @@ class UserAuthenticationMethodController(object):
             
             if self.dao.delete(oldData):
                 # Set new authentication method
-                return self.dao.save(newData)
+                if self.dao.save(newData)
+                    self.logger.debug("Authentication method saved!")
+                    showinfo_gtk(_("Authentication method saved!"),self.view)
+                    return True
+                else:
+                    self.logger.error("Authentication method failed!")
+                    showerror_gtk(_("Authentication method failed!"),self.view)
             else:
                 return False
         else:

--- a/po/es.po
+++ b/po/es.po
@@ -950,11 +950,11 @@ msgstr ""
 "nuevos datos?"
 
 #: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:344
-msgid "New authentication method saved!"
+msgid "Authentication method saved!"
 msgstr "Método de Autenticación configurado!"
 
 #: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:348
-msgid "New authentication method failed!"
+msgid "Authentication method failed!"
 msgstr "Método de Autenticación falló!"
 
 #: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:377

--- a/po/es.po
+++ b/po/es.po
@@ -1,15 +1,13 @@
-# Spanish translations for GECOS CONFIG ASSISTANT package.
-# Copyright (C) 2015 GECOS-TEAM
-# This file is distributed under the same license as the GECOS CONFIG ASSISTANT package.
-# GECOS TEAM <gecos@guadalinex.org>, 201
+# Spanish translations for PACKAGE package.
+# Copyright (C) 2015 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# root <amp_21004@yahoo.es>, 2015.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"#-#-#-#-#  es.po (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-19 16:38+0200\n"
+"POT-Creation-Date: 2016-10-11 16:52+0200\n"
 "PO-Revision-Date: 2015-09-29 17:13+0200\n"
 "Last-Translator: root <amp_21004@yahoo.es>\n"
 "Language-Team: Spanish\n"
@@ -55,7 +53,6 @@ msgid "Accept "
 msgstr "Aceptar "
 
 #: ../data/glade/localuserpopup.glade:6
-#: ../gecosws_config_assistant/view/LocalUserElemDialog.py:90
 msgid "Add local user"
 msgstr "A&ntilde;adir usuario local"
 
@@ -134,7 +131,6 @@ msgid "Confirm:"
 msgstr "Confirmar:"
 
 #: ../data/glade/gecoscon.glade:486
-#: ../gecosws_config_assistant/view/ConnectWithGecosCCDialog.py:162
 msgid "Connect to CC GECOS"
 msgstr "Conectar al CC GECOS"
 
@@ -147,9 +143,6 @@ msgid "Delete"
 msgstr "Borrar"
 
 #: ../data/glade/adsetupdata.glade:70
-#: ../gecosws_config_assistant/view/SystemStatusElemDialog.py:133
-#: ../gecosws_config_assistant/view/UserAuthDialog.py:246
-#: ../gecosws_config_assistant/view/UserAuthDialog.py:278
 msgid "Domain:"
 msgstr "Dominio:"
 
@@ -157,7 +150,6 @@ msgstr "Dominio:"
 #: ../data/glade/main.glade:27 ../data/glade/network.glade:35
 #: ../data/glade/ntp.glade:16 ../data/glade/requirements.glade:46
 #: ../data/glade/users.glade:23 ../data/glade/window.glade:35
-#: ../gecosws_config_assistant/view/MainWindow.py:74
 msgid "GECOS Config Assistant"
 msgstr "Asistente de configuración GECOS"
 
@@ -229,7 +221,6 @@ msgid "Local Users"
 msgstr "Usuarios locales"
 
 #: ../data/glade/localuserpopup.glade:45
-#: ../gecosws_config_assistant/view/SystemStatusElemDialog.py:117
 msgid "Login:"
 msgstr "Login:"
 
@@ -288,7 +279,6 @@ msgid "Password"
 msgstr "Contraseña"
 
 #: ../data/glade/adsetupdata.glade:115 ../data/glade/localuserpopup.glade:64
-#: ../gecosws_config_assistant/view/UserAuthDialog.py:281
 msgid "Password:"
 msgstr "Contraseña:"
 
@@ -333,7 +323,6 @@ msgid "System Status"
 msgstr "Estado del Sistema"
 
 #: ../data/glade/systemstatus.glade:11
-#: ../gecosws_config_assistant/view/SystemStatusElemDialog.py:87
 msgid "System status"
 msgstr "Estado del Sistema"
 
@@ -387,7 +376,6 @@ msgid "User"
 msgstr "Usuario"
 
 #: ../data/glade/adsetupdata.glade:100
-#: ../gecosws_config_assistant/view/UserAuthDialog.py:280
 msgid "User:"
 msgstr "Usuario:"
 
@@ -396,9 +384,6 @@ msgid "Users are authenticated using the INTERNAL method"
 msgstr "Los usuarios se autentican usando el método INTERNO"
 
 #: ../data/glade/adsetupdata.glade:85
-#: ../gecosws_config_assistant/view/SystemStatusElemDialog.py:134
-#: ../gecosws_config_assistant/view/UserAuthDialog.py:247
-#: ../gecosws_config_assistant/view/UserAuthDialog.py:279
 msgid "Workgroup:"
 msgstr "Gurpo de trabajo:"
 
@@ -494,31 +479,31 @@ msgstr ""
 #: ../gecosws_config_assistant/view/GecosCCSetupProgressView.py:125
 #: ../gecosws_config_assistant/view/GecosCCSetupProgressView.py:134
 #: ../gecosws_config_assistant/view/GecosCCSetupProgressView.py:139
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:335
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:341
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:347
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:357
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:384
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:394
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:450
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:463
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:477
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:490
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:560
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:573
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:597
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:612
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:635
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:657
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:667
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:718
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:728
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:755
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:768
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:777
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:788
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:797
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:814
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:353
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:359
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:365
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:375
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:402
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:412
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:468
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:481
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:495
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:508
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:578
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:591
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:615
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:630
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:653
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:675
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:685
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:736
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:746
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:773
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:786
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:795
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:806
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:815
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:832
 msgid "ERROR"
 msgstr ""
 
@@ -563,20 +548,20 @@ msgid "The password confirmation field is empty!"
 msgstr "El campo Confirmación de la clave está vacío!"
 
 #: ../gecosws_config_assistant/view/LocalUserElemDialog.py:123
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:101
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:163
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:171
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:108
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:123
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:131
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:196
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:228
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:367
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:382
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:412
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:438
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:447
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:456
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:117
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:179
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:187
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:126
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:141
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:149
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:214
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:246
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:377
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:392
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:422
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:448
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:457
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:466
 #: ../gecosws_config_assistant/controller/LocalUserController.py:78
 #: ../gecosws_config_assistant/controller/LocalUserController.py:94
 #: ../gecosws_config_assistant/controller/LocalUserController.py:103
@@ -693,121 +678,121 @@ msgstr "Vea el log para más detalles."
 msgid "Log terminal"
 msgstr "Terminal de Log"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:101
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:108
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:117
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:126
 msgid "The URL field is empty!"
 msgstr "¡El campo URL está vacío!"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:108
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:115
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:124
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:133
 msgid "Malformed URL in URL field!"
 msgstr "¡URL mal escrita en el campo URL!"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:108
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:115
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:124
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:133
 msgid "Please double-check it."
 msgstr "Por favor revise el dato."
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:127
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:150
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:434
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:545
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:143
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:168
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:452
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:563
 msgid "The certificate of this server is expired!"
 msgstr "¡El certificado de este servidor ha expirado!"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:129
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:152
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:436
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:547
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:145
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:170
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:454
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:565
 msgid "The certificate of this server is not trusted!"
 msgstr "¡No se confía en el certificado de este servidor!"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:132
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:155
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:440
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:550
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:148
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:173
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:458
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:568
 msgid "Do you want to disable the SSL certificate verification?"
 msgstr "¿Desea desactivar la validación de certificados SSL?"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:134
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:157
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:442
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:552
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:150
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:175
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:460
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:570
 msgid "Subject:"
 msgstr "Objeto:"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:135
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:158
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:443
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:553
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:151
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:176
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:461
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:571
 msgid "Issuer:"
 msgstr "Emisor:"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:136
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:159
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:444
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:554
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:152
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:177
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:462
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:572
 msgid "Serial Number:"
 msgstr "Número de serie:"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:137
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:160
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:445
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:555
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:153
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:178
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:463
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:573
 msgid "Not before:"
 msgstr "No antes:"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:137
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:160
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:445
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:555
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:153
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:178
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:463
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:573
 msgid "Not after:"
 msgstr "No después:"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:152
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:179
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:175
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:183
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:168
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:195
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:193
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:201
 msgid "Can't connect to GECOS CC!"
 msgstr "¡Imposible conectar al CC GECOS!"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:152
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:175
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:465
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:575
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:168
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:193
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:483
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:593
 msgid "SSL ERROR:"
 msgstr "ERROR de SSL:"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:163
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:123
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:179
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:141
 msgid "The Username field is empty!"
 msgstr "¡El campo Usuario está vacío!"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:171
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:131
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:187
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:149
 msgid "The Password field is empty!"
 msgstr "¡El campo Contraseña está vacío!"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:179
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:183
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:195
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:201
 msgid "Please double-check all the data and your network setup."
 msgstr "Por favor revise todos los datos y su configuración de red."
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:201
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:217
 msgid "Please wait"
 msgstr "Por favor espere"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:211
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:227
 msgid "Error getting data"
 msgstr "Error obteniendo datos"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:212
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:228
 msgid "Can't read auto setup configuration data from GECOS Control Center!"
 msgstr ""
 "¡No se pueden leer los datos de autoconfiguración desde el Centro de Control "
 "GECOS!"
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:217
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:233
 msgid "Success getting data from GECOS server"
 msgstr "Exito al obtener los datos desde el servidor GECOS"
 
@@ -816,146 +801,146 @@ msgstr "Exito al obtener los datos desde el servidor GECOS"
 msgid "Error saving NTP server data."
 msgstr "Error guardando los datos del servidor de NTP"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:196
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:214
 msgid "The GECOS workstation name field is empty!"
 msgstr "¡El campo Nombre de estación de trabajo está vacío!"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:215
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:233
 msgid "The GECOS workstation name already exist!"
 msgstr "¡El nombre de estación de trabajo ya existe!"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:215
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:233
 msgid "Please choose a different name."
 msgstr "Por favor elija un nombre diferente"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:228
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:246
 msgid "You must select an OU!"
 msgstr "¡Debe seleccionar una OU!"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:325
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:343
 msgid "Link to Chef"
 msgstr "Vincular a Chef "
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:326
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:344
 msgid "Register in GECOS CC"
 msgstr "Registrar en CC GECOS"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:331
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:354
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:364
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:503
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:648
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:678
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:716
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:725
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:735
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:745
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:811
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:824
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:349
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:372
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:382
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:521
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:666
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:696
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:734
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:743
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:753
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:763
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:829
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:842
 msgid "IN PROCESS"
 msgstr "EN PROCESO"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:351
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:361
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:500
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:645
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:675
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:683
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:722
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:732
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:742
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:808
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:821
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:830
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:369
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:379
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:518
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:663
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:693
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:701
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:740
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:750
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:760
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:826
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:839
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:848
 msgid "DONE"
 msgstr "HECHO"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:386
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:404
 msgid "There was an error while getting the client certificate"
 msgstr "Ha ocurrido un error al obtener el certificado de cliente"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:396
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:414
 msgid "There was an error while saving the client certificate"
 msgstr "Ha ocurrido un error al guardar el certificado de cliente"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:465
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:483
 msgid "Can't connect to GEMs repository!"
 msgstr "¡No se puede conectar al repositrio de GEMas!"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:479
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:497
 msgid "There was an error while adding the GEMs repository:\n"
 msgstr "Ha ocurrido un error al añadir el repositorio de GEMas:\n"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:492
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:510
 msgid "There was an error while installing a required GEM: "
 msgstr "Ha ocurrido un error al instalar una GEMa requerida: "
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:575
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:593
 msgid "Can't connect to Chef Server!"
 msgstr "¡No se puede conectar con el servidor de Chef!"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:599
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:617
 msgid "Can't create/modify /etc/chef/client.rb file"
 msgstr "¡No se puede crear/modificar el fichero  /etc/chef/client.rb!"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:614
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:632
 msgid "Can't link to chef server!"
 msgstr "¡No se ha podido vincular al servidor de Chef!"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:637
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:655
 msgid "Can't create/modify /etc/chef.control file"
 msgstr "No se puede crear/modificar el fichero /etc/chef.control"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:659
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:677
 msgid "Can't register the computer in GECOS CC"
 msgstr "No se ha podido registar el ordenador en el CC GECOS"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:669
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:687
 msgid "Can't save /etc/gcc.control file"
 msgstr "No se puede guardar el fichero /etc/gcc.control"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:706
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:724
 #, fuzzy
 msgid "Local disconnection done!"
 msgstr "¿Desconexión local?"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:710
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:728
 msgid "Unlink from Chef"
 msgstr "Desvincular de Chef "
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:711
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:729
 msgid "Unregister from GECOS CC"
 msgstr "Desregistrar del CC GECOS"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:757
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:775
 msgid "Can't unregister the computer from GECOS CC"
 msgstr "No se puede desregistrar el ordenador del CC GECOS"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:770
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:788
 msgid "Can't remove /etc/chef.control file"
 msgstr "No se puede borar el fichero /etc/chef.control"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:779
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:797
 msgid "Can't remove /etc/chef/client.pem file"
 msgstr "No se puede borrar el fichero /etc/chef/client.pem"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:790
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:808
 msgid "Can't delete Chef node"
 msgstr "No se puede borrar el nodo de Chef"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:799
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:817
 msgid "Can't remove /usr/bin/chef-client-wrapper file"
 msgstr "No se puede borrar el fichero /usr/bin/chef-client-wrapper"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:816
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:834
 msgid "Can't remove /etc/gcc.control file"
 msgstr "No se puede borrar el fichero /etc/gcc.control"
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:850
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:868
 msgid "Can't get OUs from GECOS Control Center"
 msgstr "No se pueden obtener las OUs desde el Centro de Control GECOS"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:302
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:303
 msgid ""
 "The user authentication data has changed.\n"
 "Do you want to setup the user authentication method using this new data?"
@@ -964,64 +949,72 @@ msgstr ""
 "¿Desea configurar los el método de autenticación de usuarios usando estos "
 "nuevos datos?"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:367
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:344
+msgid "New authentication method saved!"
+msgstr "Método de Autenticación configurado!"
+
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:348
+msgid "New authentication method failed!"
+msgstr "Método de Autenticación falló!"
+
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:377
 msgid "The URI field is empty!"
 msgstr "¡El campo URI está vacío!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:374
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:384
 msgid "Malformed LDAP URI!"
 msgstr "¡URI de LDAP mal formada!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:374
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:384
 msgid "Please check that the URI starts with 'ldap://' or 'ldaps://'."
 msgstr "Por favor, compruebe que la URI empieza con 'ldap://' o 'ldaps://'."
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:382
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:392
 msgid "The users base DN field is empty!"
 msgstr "¡El campo base DN de usuarios está vacío!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:389
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:399
 msgid "Can't connect to LDAP server!"
 msgstr "¡No se puede conectar al servidor de LDAP!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:389
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:464
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:399
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:474
 msgid "Please check all the fields and your network connection."
 msgstr "Por favor compruebe todos los campos y su conexión con la red!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:404
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:414
 msgid "Bad netbios hostname!"
 msgstr "¡El hosname no cumple los requisitos de Netbios!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:404
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:414
 msgid "Please change the hostname of this computer."
 msgstr "Por favor cambie el hostname de este ordenador."
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:412
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:422
 msgid "The Domain field is empty!"
 msgstr "¡El campo Dominio está vacío!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:429
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:439
 msgid "Can't resolv the Active Directory Domain name!"
 msgstr "¡No se puede resolver el nombre de dominio de Active Directory!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:430
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:440
 msgid "Please check the Domain field and your DNS configuration."
 msgstr "Por favor compurebe el campo Dominio y su configuración de DNS."
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:438
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:448
 msgid "The Workgroup field is empty!"
 msgstr "El campo Grupo de trabajo está vacío!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:446
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:456
 msgid "The AD administrator user field is empty!"
 msgstr "¡El campo usuario Administrador AD está vacío!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:455
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:465
 msgid "The AD administrator password field is empty!"
 msgstr "¡El campo contraseña de administrador AD está vacío!"
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:463
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:473
 msgid "Can't connect to Active Directory server!"
 msgstr "¡No se puede conectar con el servidor de Active Directory!"
 

--- a/po/gecosws-config-assistant.pot
+++ b/po/gecosws-config-assistant.pot
@@ -588,11 +588,11 @@ msgid ""
 msgstr ""
 
 #: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:344
-msgid "New authentication method saved!"
+msgid "Authentication method saved!"
 msgstr ""
 
 #: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:348
-msgid "New authentication method failed!"
+msgid "Authentication method failed!"
 msgstr ""
 
 #: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:377

--- a/po/gecosws-config-assistant.pot
+++ b/po/gecosws-config-assistant.pot
@@ -1,17 +1,17 @@
-# GECOS CONFIG ASSISTANT.
-# Copyright (C) 2015
-# This file is distributed under the same license as the gecos-config-assistant package.
-# GECOS TEAM <gecos@guadalinex.org>, 2015.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: 2.1.1\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-19 16:38+0200\n"
+"POT-Creation-Date: 2018-07-02 11:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: GECOS TEAM <gecos@guadalinex.org>\n"
-"Language-Team: GECOS TEAM <gecos@guadalinex.org>\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
@@ -66,6 +66,7 @@ msgstr ""
 msgid "Method:"
 msgstr ""
 
+#. text
 #: ../gecosws_config_assistant/view/SystemStatusElemDialog.py:133
 #: ../gecosws_config_assistant/view/UserAuthDialog.py:246
 #: ../gecosws_config_assistant/view/UserAuthDialog.py:278
@@ -101,37 +102,39 @@ msgid ""
 "Please double-check all the fields"
 msgstr ""
 
+#. Error adding GEMs repository
+#. Error installing a GEM
 #: ../gecosws_config_assistant/view/GecosCCSetupProgressView.py:106
 #: ../gecosws_config_assistant/view/GecosCCSetupProgressView.py:111
 #: ../gecosws_config_assistant/view/GecosCCSetupProgressView.py:116
 #: ../gecosws_config_assistant/view/GecosCCSetupProgressView.py:125
 #: ../gecosws_config_assistant/view/GecosCCSetupProgressView.py:134
 #: ../gecosws_config_assistant/view/GecosCCSetupProgressView.py:139
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:335
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:341
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:347
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:357
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:384
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:394
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:450
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:463
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:477
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:490
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:560
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:573
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:597
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:612
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:635
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:657
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:667
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:718
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:728
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:755
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:768
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:777
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:788
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:797
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:814
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:353
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:359
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:365
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:375
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:402
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:412
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:468
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:481
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:495
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:508
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:578
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:591
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:615
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:630
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:653
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:675
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:685
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:736
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:746
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:773
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:786
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:795
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:806
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:815
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:832
 msgid "ERROR"
 msgstr ""
 
@@ -184,20 +187,20 @@ msgid "The password confirmation field is empty!"
 msgstr ""
 
 #: ../gecosws_config_assistant/view/LocalUserElemDialog.py:123
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:101
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:163
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:171
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:108
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:123
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:131
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:196
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:228
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:367
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:382
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:412
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:438
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:447
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:456
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:117
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:179
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:187
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:126
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:141
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:149
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:214
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:246
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:377
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:392
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:422
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:448
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:457
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:466
 #: ../gecosws_config_assistant/controller/LocalUserController.py:78
 #: ../gecosws_config_assistant/controller/LocalUserController.py:94
 #: ../gecosws_config_assistant/controller/LocalUserController.py:103
@@ -252,6 +255,7 @@ msgstr ""
 msgid "Please fill the data to setup the LDAP authentication method."
 msgstr ""
 
+#. text
 #: ../gecosws_config_assistant/view/UserAuthDialog.py:214
 msgid "LDAP server URI:"
 msgstr ""
@@ -314,329 +318,341 @@ msgstr ""
 msgid "Log terminal"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:101
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:108
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:117
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:126
 msgid "The URL field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:108
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:115
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:124
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:133
 msgid "Malformed URL in URL field!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:108
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:115
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:124
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:133
 msgid "Please double-check it."
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:127
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:150
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:434
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:545
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:143
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:168
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:452
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:563
 msgid "The certificate of this server is expired!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:129
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:152
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:436
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:547
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:145
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:170
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:454
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:565
 msgid "The certificate of this server is not trusted!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:132
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:155
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:440
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:550
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:148
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:173
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:458
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:568
 msgid "Do you want to disable the SSL certificate verification?"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:134
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:157
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:442
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:552
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:150
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:175
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:460
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:570
 msgid "Subject:"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:135
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:158
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:443
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:553
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:151
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:176
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:461
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:571
 msgid "Issuer:"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:136
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:159
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:444
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:554
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:152
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:177
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:462
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:572
 msgid "Serial Number:"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:137
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:160
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:445
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:555
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:153
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:178
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:463
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:573
 msgid "Not before:"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:137
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:160
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:445
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:555
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:153
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:178
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:463
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:573
 msgid "Not after:"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:152
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:179
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:175
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:183
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:168
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:195
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:193
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:201
 msgid "Can't connect to GECOS CC!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:152
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:175
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:465
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:575
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:168
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:193
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:483
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:593
 msgid "SSL ERROR:"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:163
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:123
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:179
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:141
 msgid "The Username field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:171
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:131
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:187
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:149
 msgid "The Password field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:179
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:183
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:195
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:201
 msgid "Please double-check all the data and your network setup."
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:201
+#. Show process view
+#. Get auto setup JSON
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:217
 msgid "Please wait"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:211
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:227
 msgid "Error getting data"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:212
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:228
 msgid "Can't read auto setup configuration data from GECOS Control Center!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/AutoSetupController.py:217
+#: ../gecosws_config_assistant/controller/AutoSetupController.py:233
 msgid "Success getting data from GECOS server"
 msgstr ""
 
+#. Show error message
 #: ../gecosws_config_assistant/controller/NTPServerController.py:87
 #: ../gecosws_config_assistant/controller/NTPServerController.py:91
 msgid "Error saving NTP server data."
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:196
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:214
 msgid "The GECOS workstation name field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:215
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:233
 msgid "The GECOS workstation name already exist!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:215
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:233
 msgid "Please choose a different name."
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:228
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:246
 msgid "You must select an OU!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:325
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:343
 msgid "Link to Chef"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:326
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:344
 msgid "Register in GECOS CC"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:331
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:354
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:364
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:503
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:648
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:678
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:716
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:725
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:735
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:745
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:811
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:824
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:349
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:372
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:382
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:521
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:666
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:696
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:734
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:743
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:753
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:763
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:829
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:842
 msgid "IN PROCESS"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:351
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:361
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:500
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:645
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:675
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:683
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:722
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:732
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:742
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:808
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:821
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:830
+#. We don't need any certificate to unlink from Chef or GECOS CC
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:369
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:379
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:518
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:663
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:693
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:701
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:740
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:750
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:760
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:826
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:839
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:848
 msgid "DONE"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:386
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:404
 msgid "There was an error while getting the client certificate"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:396
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:414
 msgid "There was an error while saving the client certificate"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:465
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:483
 msgid "Can't connect to GEMs repository!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:479
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:497
 msgid "There was an error while adding the GEMs repository:\n"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:492
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:510
 msgid "There was an error while installing a required GEM: "
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:575
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:593
 msgid "Can't connect to Chef Server!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:599
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:617
 msgid "Can't create/modify /etc/chef/client.rb file"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:614
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:632
 msgid "Can't link to chef server!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:637
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:655
 msgid "Can't create/modify /etc/chef.control file"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:659
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:677
 msgid "Can't register the computer in GECOS CC"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:669
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:687
 msgid "Can't save /etc/gcc.control file"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:706
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:724
 msgid "Local disconnection done!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:710
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:728
 msgid "Unlink from Chef"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:711
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:729
 msgid "Unregister from GECOS CC"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:757
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:775
 msgid "Can't unregister the computer from GECOS CC"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:770
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:788
 msgid "Can't remove /etc/chef.control file"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:779
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:797
 msgid "Can't remove /etc/chef/client.pem file"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:790
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:808
 msgid "Can't delete Chef node"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:799
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:817
 msgid "Can't remove /usr/bin/chef-client-wrapper file"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:816
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:834
 msgid "Can't remove /etc/gcc.control file"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:850
+#: ../gecosws_config_assistant/controller/ConnectWithGecosCCController.py:868
 msgid "Can't get OUs from GECOS Control Center"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:302
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:303
 msgid ""
 "The user authentication data has changed.\n"
 "Do you want to setup the user authentication method using this new data?"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:367
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:344
+msgid "New authentication method saved!"
+msgstr ""
+
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:348
+msgid "New authentication method failed!"
+msgstr ""
+
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:377
 msgid "The URI field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:374
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:384
 msgid "Malformed LDAP URI!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:374
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:384
 msgid "Please check that the URI starts with 'ldap://' or 'ldaps://'."
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:382
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:392
 msgid "The users base DN field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:389
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:399
 msgid "Can't connect to LDAP server!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:389
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:464
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:399
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:474
 msgid "Please check all the fields and your network connection."
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:404
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:414
 msgid "Bad netbios hostname!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:404
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:414
 msgid "Please change the hostname of this computer."
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:412
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:422
 msgid "The Domain field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:429
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:439
 msgid "Can't resolv the Active Directory Domain name!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:430
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:440
 msgid "Please check the Domain field and your DNS configuration."
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:438
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:448
 msgid "The Workgroup field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:446
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:456
 msgid "The AD administrator user field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:455
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:465
 msgid "The AD administrator password field is empty!"
 msgstr ""
 
-#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:463
+#: ../gecosws_config_assistant/controller/UserAuthenticationMethodController.py:473
 msgid "Can't connect to Active Directory server!"
 msgstr ""
 

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,7 @@ class Check(Command):
 
 DistUtilsExtra.auto.setup(
     name='gecosws-config-assistant',
-    version='2.1.3-1gecos1',
+    version='2.1.4-1gecos1',
     license='GPL-2',
     author='GECOS Team',
     author_email='gecos@guadalinex.org',


### PR DESCRIPTION
-  Message error: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
- Shows info message when authentication method is configured.