### PR TITLE
Fix Active Directory user login configuration in GECOS V4

### DIFF
--- a/gecosws_config_assistant/dao/UserAuthenticationMethodDAO.py
+++ b/gecosws_config_assistant/dao/UserAuthenticationMethodDAO.py
@@ -643,7 +643,8 @@ class UserAuthenticationMethodDAO(object):
         if self.sssd_version is not None:
             major, minor, _ = self.pm.parse_version_number(self.sssd_version)
 
-            if major > 1 or (major == 1 and minor > 11):
+            if ((major > 1 or (major == 1 and minor > 11))
+                and self.pm.is_package_installed('mdm')):
                 extra_conf_lines = 'ad_gpo_map_interactive = +mdm, +polkit-1'
 
         self.logger.debug('Save /etc/sssd/sssd.conf file')


### PR DESCRIPTION
After updating a GECOS V4 installation the Active Directory user login configuration fails because of 'ad_gpo_map_interactive = +mdm, +polkit-1'  line in /etc/sssd/sssd.conf file.

With this change the 'ad_gpo_map_interactive = +mdm, +polkit-1' line will only be used when MDM is installed.

Also I had to install "samba-dsdb-modules" to fix the following error message:
  `ldb: unable to stat module /usr/lib/x86_64-linux-gnu/samba/ldb : No such file or directory`

